### PR TITLE
Add find security bugs plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,13 @@
                         <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
                         <!--Exclude sources-->
                         <excludeFilterFile>${mavan.findbugsplugin.exclude.file}</excludeFilterFile>
+                        <plugins>
+                            <plugin>
+                                <groupId>com.h3xstream.findsecbugs</groupId>
+                                <artifactId>findsecbugs-plugin</artifactId>
+                                <version>LATEST</version> <!-- Auto-update to the latest stable -->
+                            </plugin>
+                        </plugins>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This pull request adds findsecbugs-plugin [1], [2] to let all builds execute static security scans at the build time. It comes as a sub plugin of findbugs plugin. Thanks!

[1] http://find-sec-bugs.github.io/
[2] https://github.com/find-sec-bugs/find-sec-bugs/wiki/Maven-configuration