### PR TITLE
Remove 'wso2-public' repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,20 @@
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 Releases Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
                 <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>wso2.releases2</id>
+            <name>WSO2 Releases Repository 2</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/wso2maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
             </releases>
         </repository>
 
@@ -65,7 +74,7 @@
         <repository>
             <id>wso2.snapshots</id>
             <name>WSO2 Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -74,15 +83,16 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-
         <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
+            <id>wso2.snapshots2</id>
+            <name>WSO2 Snapshot Repository 2</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/wso2.maven2.snapshot/</url>
+            <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>
@@ -98,6 +108,16 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </pluginRepository>
+        <pluginRepository>
+            <id>wso2.releases2</id>
+            <name>WSO2 Releases Repository 2</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/wso2maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </releases>
+        </pluginRepository>
+
 
         <pluginRepository>
             <id>wso2.snapshots</id>
@@ -111,15 +131,16 @@
                 <enabled>false</enabled>
             </releases>
         </pluginRepository>
-
         <pluginRepository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
+            <id>wso2.snapshots2</id>
+            <name>WSO2 Snapshot Repository 2</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/wso2.maven2.snapshot/</url>
+            <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
             </releases>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
Remove the repository to fetch artifacts from Maven central directly.
Add second release and snapshot WSO2 repositories.