### PR TITLE
Update FindBugs Maven Plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
         <clirr.maven.plugin.version>2.7</clirr.maven.plugin.version>
         <apache.source.release.assembly.descriptor.version>1.0.5</apache.source.release.assembly.descriptor.version>
         <maven.checkstyleplugin.version>2.17</maven.checkstyleplugin.version>
-        <maven.findbugsplugin.version>3.0.3</maven.findbugsplugin.version>
+        <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
 
         <!-- Other dependency versions -->


### PR DESCRIPTION
## Purpose

Upgrade the FindBugs Maven Plugin version to allow compatibility with Maven 3.6.0+.

## Goals
Allow the Parent POM to be used with Maven 3.6.0+.

## Approach
Upgrade the FindBugs Maven Plugin version from 3.0.3 to 3.0.5.

## User stories
N/A

## Release note
Compatible with Maven 3.6.0+.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A